### PR TITLE
Fix windows (vs/msvc) build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,12 @@ elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang*")
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
     target_compile_options(warnings INTERFACE /W4)
 endif()
+
 add_library(sanitizers INTERFACE)
+if ((${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang*"))
 target_link_libraries(sanitizers INTERFACE -fsanitize=address -fsanitize=undefined)
 target_compile_options(sanitizers INTERFACE -fsanitize=address -fsanitize=undefined)
+endif()
 
 add_library(ser)
 file(GLOB_RECURSE SER_SOURCE_FILES CONFIGURE_DEPENDS "3rd-party/ser/*.cpp")

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1,0 +1,24 @@
+#include "file.hpp"
+#include <algorithm>
+#include <cstring>
+#include <cerrno>
+
+UniqueFile open_file(std::filesystem::path const &path, char const *mode) noexcept
+{
+#ifdef _WIN32
+  // widen the mode string to wchar_t
+  wchar_t buf[32];
+  std::size_t const size = std::strlen(mode);
+  if (size >= std::size(buf))
+  {
+    errno = E2BIG;
+    return nullptr;
+  }
+    
+  *std::copy(mode, mode + size, buf) = L'\0';
+
+  return UniqueFile(_wfopen(path.c_str(), buf));
+#else
+  return UniqueFile(std::fopen(path.c_str(), mode));
+#endif
+}

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+
+struct FileDeleter
+{
+  void operator()(std::FILE *fp) const noexcept { std::fclose(fp); }
+};
+
+using UniqueFile = std::unique_ptr<std::FILE, FileDeleter>;
+
+// just like fopen, return null on error setting errno
+UniqueFile open_file(std::filesystem::path const &path, char const *mode) noexcept;

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -1,4 +1,5 @@
 #include "font.hpp"
+#include "file.hpp"
 #include <log/log.hpp>
 #include <sstream>
 
@@ -23,10 +24,12 @@ namespace
   };
 } // namespace
 
-Font::Font(std::string file, int ptsize)
+Font::Font(std::filesystem::path file, int ptsize)
   : file_(std::move(file)), ptsize_(ptsize), font([this]() {
       FontInitializer::init();
-      return TTF_OpenFont(file_.c_str(), ptsize_);
+      auto fp = open_file(file_, "rb");
+      auto *rw = SDL_RWFromFP(fp.get(), SDL_FALSE);
+      return TTF_OpenFontRW(rw, SDL_TRUE, ptsize_);
     }())
 {
   if (!font)
@@ -105,7 +108,7 @@ auto Font::getSize(const std::string &txt) const -> glm::vec2
   return glm::vec2{w, h};
 }
 
-auto Font::file() const -> const std::string &
+auto Font::file() const -> const std::filesystem::path &
 {
   return file_;
 }

--- a/src/font.hpp
+++ b/src/font.hpp
@@ -2,6 +2,7 @@
 #include "texture.hpp"
 #include <SDL_opengl.h>
 #include <SDL_ttf.h>
+#include <filesystem>
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
 #include <list>
@@ -11,15 +12,15 @@
 class Font
 {
 public:
-  Font(std::string, int);
+  Font(std::filesystem::path, int);
   ~Font();
   auto render(glm::vec2, const std::string &) -> void;
   auto getSize(const std::string &) const -> glm::vec2;
-  auto file() const -> const std::string &;
+  auto file() const -> const std::filesystem::path &;
   auto ptsize() const -> int;
 
 private:
-  std::string file_;
+  std::filesystem::path file_;
   int ptsize_;
   decltype(TTF_OpenFont("", 0)) font;
   mutable std::unordered_map<std::string, std::pair<Texture, std::list<std::string>::iterator>>

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -45,20 +45,20 @@ auto Lib::queryTwitch(const std::string &v) -> std::shared_ptr<Twitch>
   return shared;
 }
 
-auto Lib::queryFont(const std::string &path, int size) -> std::shared_ptr<Font>
+auto Lib::queryFont(const std::filesystem::path &path, int size) -> std::shared_ptr<Font>
 {
-  auto it = fonts.find({path, size});
+  auto it = fonts.find(std::make_pair(std::cref(path), size));
   if (it != std::end(fonts))
   {
-    auto shared = it->second.lock();
-    if (shared)
+    if (auto shared = it->second.lock())
       return shared;
-    fonts.erase(it);
   }
-  auto shared = std::make_shared<Font>(path, size);
-  auto tmp = fonts.emplace(std::pair{path, size}, shared);
-  assert(tmp.second);
-  return shared;
+
+  auto font = std::make_shared<Font>(path, size);
+  fonts.emplace_hint(
+    it, std::piecewise_construct, std::forward_as_tuple(path, size), std::forward_as_tuple(font));
+
+  return font;
 }
 
 auto Lib::flush() -> void

--- a/src/lib.hpp
+++ b/src/lib.hpp
@@ -6,6 +6,7 @@
 #include "gpt.hpp"
 #include "texture.hpp"
 #include "twitch.hpp"
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <unordered_map>
@@ -15,7 +16,7 @@ class Lib
 public:
   Lib(class Preferences &, uv::Uv &, HttpClient &);
   auto flush() -> void;
-  auto queryFont(const std::string &, int size) -> std::shared_ptr<Font>;
+  auto queryFont(const std::filesystem::path &path, int size) -> std::shared_ptr<Font>;
   auto queryTex(const std::string &, bool isUi = false) -> std::shared_ptr<const Texture>;
   auto queryTwitch(const std::string &) -> std::shared_ptr<Twitch>;
   auto queryAzureTts(class AudioSink &) -> std::shared_ptr<AzureTts>;
@@ -28,7 +29,7 @@ private:
   std::reference_wrapper<HttpClient> httpClient;
   std::map<std::pair<std::string, bool>, std::weak_ptr<const Texture>> textures;
   std::unordered_map<std::string, std::weak_ptr<Twitch>> twitchChannels;
-  std::map<std::pair<std::string, int>, std::weak_ptr<Font>> fonts;
+  std::map<std::pair<std::filesystem::path, int>, std::weak_ptr<Font>> fonts;
   AzureToken azureToken;
   std::weak_ptr<AzureTts> azureTts;
   std::weak_ptr<AzureStt> azureStt;

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -1,8 +1,10 @@
 #include "texture.hpp"
+#include "file.hpp"
 #include <cassert>
 #include <log/log.hpp>
 #include <sdlpp/sdlpp.hpp>
 #include <sstream>
+#include <stdio.h>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdisabled-macro-expansion"
 #pragma GCC diagnostic ignored "-Wextra-semi-stmt"
@@ -32,7 +34,8 @@ Texture::Texture(uv::Uv &uv, std::string aPath, bool isUi)
         {
           LOG(e.what());
           auto engineImgPath = sdl::get_base_path() / "assets/corrupted.png";
-          auto ret = stbi_load(engineImgPath.c_str(), &w_, &h_, &ch_, STBI_rgb_alpha);
+          auto fp = open_file(engineImgPath, "rb");
+          auto ret = stbi_load_from_file(fp.get(), &w_, &h_, &ch_, STBI_rgb_alpha);
           if (!ret)
           {
             std::ostringstream ss;
@@ -45,7 +48,8 @@ Texture::Texture(uv::Uv &uv, std::string aPath, bool isUi)
       else
       {
         auto engineImgPath = sdl::get_base_path() / "assets" / path_.substr(7);
-        auto ret = stbi_load(engineImgPath.c_str(), &w_, &h_, &ch_, STBI_rgb_alpha);
+        auto fp = open_file(engineImgPath, "rb");
+        auto ret = stbi_load_from_file(fp.get(), &w_, &h_, &ch_, STBI_rgb_alpha);
         if (!ret)
         {
           std::ostringstream ss;


### PR DESCRIPTION
Many SDL & stb functions that expect a filename use `char const*`. but `std::filesystem::path` uses `wchar_t` as the value type.
However, these functions are essentially just wrappers for `fopen`, instead we can use `_wfopen` which uses an unicode string instead of an ansi string; the `open_file` helper functions is added to wrap this behavior in win32 and linux.
As a final note: if neither `t` or `b` is specified in the open mode, the default `t` is used, so make sure to use `b` for binary files.

